### PR TITLE
Block `Realst` crypto-stealing malware used in fake meeting apps targeting people in the Web3 space

### DIFF
--- a/src/blacklists/custom-ip-block-lists/ip-realst.txt
+++ b/src/blacklists/custom-ip-block-lists/ip-realst.txt
@@ -1,0 +1,15 @@
+# Crypto Firewall
+# Blocking Web Browser Crypto Malware and Phishing Websites
+#
+# Blocking: Realst Malware Custom List
+#
+# Homepage: https://github.com/chartingshow/crypto-firewall
+# Contribute: https://github.com/chartingshow/crypto-firewall/issues
+# License: GPL-3.0 license
+#
+# Last modified: 7 December 2024
+#
+
+139.162.179.170
+172.104.133.212
+199.247.4.86

--- a/src/blacklists/hosts.txt
+++ b/src/blacklists/hosts.txt
@@ -4258,6 +4258,7 @@
 0.0.0.0 clubmanager.net.ar
 0.0.0.0 clubs-goldys.xyz
 0.0.0.0 clubver.shop
+0.0.0.0 clusee.com
 0.0.0.0 clusterfunds.i.ng
 0.0.0.0 cmbavocat.fr
 0.0.0.0 cmbefalcljjblia.top
@@ -5233,6 +5234,7 @@
 0.0.0.0 delivery-albai.com
 0.0.0.0 delivery-pays.shop
 0.0.0.0 deliverydudez.com
+0.0.0.0 deliverynetwork.observer
 0.0.0.0 dellhummock.com
 0.0.0.0 delmarlc.net
 0.0.0.0 deloxfunds.org
@@ -11607,8 +11609,11 @@
 0.0.0.0 medusa-stealer.cc
 0.0.0.0 meelaylesa.xyz
 0.0.0.0 meeronixt.com
+0.0.0.0 meeten.us
 0.0.0.0 meetinglove.life
+0.0.0.0 meetio.one
 0.0.0.0 meetmenowbangkok.com
+0.0.0.0 meetone.gg
 0.0.0.0 meetonews.xyz
 0.0.0.0 meetsusolutions.com
 0.0.0.0 mefound.com

--- a/src/blacklists/nomalware-beta.txt
+++ b/src/blacklists/nomalware-beta.txt
@@ -4270,6 +4270,7 @@
 ||clubmanager.net.ar^$third-party
 ||clubs-goldys.xyz^$third-party
 ||clubver.shop^$third-party
+||clusee.com^$third-party
 ||clusterfunds.i.ng^$third-party
 ||cmbavocat.fr^$third-party
 ||cmbefalcljjblia.top^$third-party
@@ -5246,6 +5247,7 @@
 ||delivery-albai.com^$third-party
 ||delivery-pays.shop^$third-party
 ||deliverydudez.com^$third-party
+||deliverynetwork.observer^$third-party
 ||dellhummock.com^$third-party
 ||delmarlc.net^$third-party
 ||deloxfunds.org^$third-party
@@ -11624,8 +11626,11 @@
 ||medusa-stealer.cc^$third-party
 ||meelaylesa.xyz^$third-party
 ||meeronixt.com^$third-party
+||meeten.us^$third-party
 ||meetinglove.life^$third-party
+||meetio.one^$third-party
 ||meetmenowbangkok.com^$third-party
+||meetone.gg^$third-party
 ||meetonews.xyz^$third-party
 ||meetsusolutions.com^$third-party
 ||mefound.com^$third-party

--- a/src/blacklists/nomalware-full.txt
+++ b/src/blacklists/nomalware-full.txt
@@ -4270,6 +4270,7 @@
 ||clubmanager.net.ar^$third-party
 ||clubs-goldys.xyz^$third-party
 ||clubver.shop^$third-party
+||clusee.com^$third-party
 ||clusterfunds.i.ng^$third-party
 ||cmbavocat.fr^$third-party
 ||cmbefalcljjblia.top^$third-party
@@ -5246,6 +5247,7 @@
 ||delivery-albai.com^$third-party
 ||delivery-pays.shop^$third-party
 ||deliverydudez.com^$third-party
+||deliverynetwork.observer^$third-party
 ||dellhummock.com^$third-party
 ||delmarlc.net^$third-party
 ||deloxfunds.org^$third-party
@@ -11624,8 +11626,11 @@
 ||medusa-stealer.cc^$third-party
 ||meelaylesa.xyz^$third-party
 ||meeronixt.com^$third-party
+||meeten.us^$third-party
 ||meetinglove.life^$third-party
+||meetio.one^$third-party
 ||meetmenowbangkok.com^$third-party
+||meetone.gg^$third-party
 ||meetonews.xyz^$third-party
 ||meetsusolutions.com^$third-party
 ||mefound.com^$third-party

--- a/src/blacklists/nomalware-lite.txt
+++ b/src/blacklists/nomalware-lite.txt
@@ -4270,6 +4270,7 @@
 ||clubmanager.net.ar^$third-party
 ||clubs-goldys.xyz^$third-party
 ||clubver.shop^$third-party
+||clusee.com^$third-party
 ||clusterfunds.i.ng^$third-party
 ||cmbavocat.fr^$third-party
 ||cmbefalcljjblia.top^$third-party
@@ -5246,6 +5247,7 @@
 ||delivery-albai.com^$third-party
 ||delivery-pays.shop^$third-party
 ||deliverydudez.com^$third-party
+||deliverynetwork.observer^$third-party
 ||dellhummock.com^$third-party
 ||delmarlc.net^$third-party
 ||deloxfunds.org^$third-party
@@ -11624,8 +11626,11 @@
 ||medusa-stealer.cc^$third-party
 ||meelaylesa.xyz^$third-party
 ||meeronixt.com^$third-party
+||meeten.us^$third-party
 ||meetinglove.life^$third-party
+||meetio.one^$third-party
 ||meetmenowbangkok.com^$third-party
+||meetone.gg^$third-party
 ||meetonews.xyz^$third-party
 ||meetsusolutions.com^$third-party
 ||mefound.com^$third-party

--- a/src/blacklists/nomalware-mega.txt
+++ b/src/blacklists/nomalware-mega.txt
@@ -4270,6 +4270,7 @@
 ||clubmanager.net.ar^$third-party
 ||clubs-goldys.xyz^$third-party
 ||clubver.shop^$third-party
+||clusee.com^$third-party
 ||clusterfunds.i.ng^$third-party
 ||cmbavocat.fr^$third-party
 ||cmbefalcljjblia.top^$third-party
@@ -5246,6 +5247,7 @@
 ||delivery-albai.com^$third-party
 ||delivery-pays.shop^$third-party
 ||deliverydudez.com^$third-party
+||deliverynetwork.observer^$third-party
 ||dellhummock.com^$third-party
 ||delmarlc.net^$third-party
 ||deloxfunds.org^$third-party
@@ -11624,8 +11626,11 @@
 ||medusa-stealer.cc^$third-party
 ||meelaylesa.xyz^$third-party
 ||meeronixt.com^$third-party
+||meeten.us^$third-party
 ||meetinglove.life^$third-party
+||meetio.one^$third-party
 ||meetmenowbangkok.com^$third-party
+||meetone.gg^$third-party
 ||meetonews.xyz^$third-party
 ||meetsusolutions.com^$third-party
 ||mefound.com^$third-party


### PR DESCRIPTION
Issue: https://github.com/chartingshow/crypto-firewall/issues/656
