### PR TITLE
Block `Glove Stealer` a malware that bypasses Chrome's App-Bound Encryption, stealing data from browsers, crypto wallets and 2FA authenticators

### DIFF
--- a/src/blacklists/hosts.txt
+++ b/src/blacklists/hosts.txt
@@ -8572,6 +8572,7 @@
 0.0.0.0 hdhub4u.help
 0.0.0.0 hdmilg.xyz
 0.0.0.0 hdoki.org
+0.0.0.0 hdsjfkgsadoghdsiougds.space
 0.0.0.0 hdtrenity.com
 0.0.0.0 headlinepost.net
 0.0.0.0 headspace.ng
@@ -19277,6 +19278,7 @@
 0.0.0.0 vojexe.com
 0.0.0.0 vollfisioterapia.com.br
 0.0.0.0 volnadsol.ru
+0.0.0.0 volt-texs.online
 0.0.0.0 vonanevynal.xyz
 0.0.0.0 vonavu.com
 0.0.0.0 vonfierce.sbs

--- a/src/blacklists/nomalware-beta.txt
+++ b/src/blacklists/nomalware-beta.txt
@@ -8582,6 +8582,7 @@
 ||hdhub4u.help^$third-party
 ||hdmilg.xyz^$third-party
 ||hdoki.org^$third-party
+||hdsjfkgsadoghdsiougds.space^$third-party
 ||hdtrenity.com^$third-party
 ||headlinepost.net^$third-party
 ||headspace.ng^$third-party
@@ -19188,6 +19189,7 @@
 ||vojexe.com^$third-party
 ||vollfisioterapia.com.br^$third-party
 ||volnadsol.ru^$third-party
+||volt-texs.online^$third-party
 ||vonanevynal.xyz^$third-party
 ||vonavu.com^$third-party
 ||vonfierce.sbs^$third-party

--- a/src/blacklists/nomalware-full.txt
+++ b/src/blacklists/nomalware-full.txt
@@ -8582,6 +8582,7 @@
 ||hdhub4u.help^$third-party
 ||hdmilg.xyz^$third-party
 ||hdoki.org^$third-party
+||hdsjfkgsadoghdsiougds.space^$third-party
 ||hdtrenity.com^$third-party
 ||headlinepost.net^$third-party
 ||headspace.ng^$third-party
@@ -19188,6 +19189,7 @@
 ||vojexe.com^$third-party
 ||vollfisioterapia.com.br^$third-party
 ||volnadsol.ru^$third-party
+||volt-texs.online^$third-party
 ||vonanevynal.xyz^$third-party
 ||vonavu.com^$third-party
 ||vonfierce.sbs^$third-party

--- a/src/blacklists/nomalware-lite.txt
+++ b/src/blacklists/nomalware-lite.txt
@@ -8582,6 +8582,7 @@
 ||hdhub4u.help^$third-party
 ||hdmilg.xyz^$third-party
 ||hdoki.org^$third-party
+||hdsjfkgsadoghdsiougds.space^$third-party
 ||hdtrenity.com^$third-party
 ||headlinepost.net^$third-party
 ||headspace.ng^$third-party
@@ -19188,6 +19189,7 @@
 ||vojexe.com^$third-party
 ||vollfisioterapia.com.br^$third-party
 ||volnadsol.ru^$third-party
+||volt-texs.online^$third-party
 ||vonanevynal.xyz^$third-party
 ||vonavu.com^$third-party
 ||vonfierce.sbs^$third-party

--- a/src/blacklists/nomalware-mega.txt
+++ b/src/blacklists/nomalware-mega.txt
@@ -8582,6 +8582,7 @@
 ||hdhub4u.help^$third-party
 ||hdmilg.xyz^$third-party
 ||hdoki.org^$third-party
+||hdsjfkgsadoghdsiougds.space^$third-party
 ||hdtrenity.com^$third-party
 ||headlinepost.net^$third-party
 ||headspace.ng^$third-party
@@ -19188,6 +19189,7 @@
 ||vojexe.com^$third-party
 ||vollfisioterapia.com.br^$third-party
 ||volnadsol.ru^$third-party
+||volt-texs.online^$third-party
 ||vonanevynal.xyz^$third-party
 ||vonavu.com^$third-party
 ||vonfierce.sbs^$third-party


### PR DESCRIPTION
Issue: https://github.com/chartingshow/crypto-firewall/issues/658
